### PR TITLE
Match pid file location from alpine package manager

### DIFF
--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -1,8 +1,8 @@
-## Version 2018/08/16 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx.conf
+## Version 2018/12/21 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx.conf
 
 user abc;
 worker_processes 4;
-pid /run/nginx.pid;
+pid /run/nginx/nginx.pid;
 include /etc/nginx/modules/*.conf;
 
 events {

--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -3,7 +3,7 @@
 # make our folders
 mkdir -p \
 	/config/{nginx/site-confs,www,log/nginx,keys,log/php,php} \
-	/run \
+	/run/nginx \
 	/var/lib/nginx/tmp/client_body \
 	/var/tmp/nginx
 


### PR DESCRIPTION
commands like nginx -s reload wouldn't work to apply changes without starting the docker. https://git.alpinelinux.org/cgit/aports/tree/main/nginx/nginx.initd

This of course won't retroactively, but going forward the pid file should be in the right place.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

