### PR TITLE
reap zombie nginx processes

### DIFF
--- a/root/etc/services.d/nginx/run
+++ b/root/etc/services.d/nginx/run
@@ -1,6 +1,6 @@
 #!/usr/bin/with-contenv bash
 
-if ps aux | grep [n]ginx: > /dev/null; then
+if pgrep -f "[n]ginx:" > /dev/null; then
   pkill [n]ginx:
 fi
 

--- a/root/etc/services.d/nginx/run
+++ b/root/etc/services.d/nginx/run
@@ -1,3 +1,7 @@
 #!/usr/bin/with-contenv bash
-exec /usr/sbin/nginx -c /config/nginx/nginx.conf
 
+if ps aux | grep [n]ginx: > /dev/null; then
+  pkill [n]ginx:
+fi
+
+exec /usr/sbin/nginx -c /config/nginx/nginx.conf


### PR DESCRIPTION
When the nginx master process is killed, it leaves behind the worker and cache manager processes, which prevents s6 from starting a new master process, throwing it in a loop, causing the logs to get very large and potentially causing the server to run out of space.

This PR will reap zombies before attempting to start nginx.