### PR TITLE
Executing php-fpm with-contenv, more consistent with other services

### DIFF
--- a/root/etc/services.d/php-fpm/run
+++ b/root/etc/services.d/php-fpm/run
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
 
 exec /usr/sbin/php-fpm7 -F


### PR DESCRIPTION
## Description:
Env-vars didn't come through from docker-environment to php-fpm so far, someone (like me) might use environement variables within php-fpm. It is also more consitent to the other two services in this repo (nginx, cron)

## Benefits of this PR and context:
- In nextcloud (and other inherited images) I can use something like this as config.php (only relevant parts):
> $CONFIG = array ( 'dbpassword' => getenv("MYSQL_PASSWORD"));
- To fully work you will need to change  /etc/php7/php-fpm.d/www2.conf to
> [www]
> clear_env = no
- The advantage is: You can check in this conf-file wherever you want, without security issues, you just need to secure your .env-file (or whatever you use to inject environment-variables into your docker-container)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- It works well in my nextcloud 18 container and I can access docker-environment-variables now
<!--- Include details of your testing environment, and the tests you ran to -->
- In nextcloud I have a config.php, which contains only non-security-sensitive-data like version and some others and a sensitive.config.php which uses getenv instead of plaintext passwords. Both files are checked in (since there are no plaintext-passwords or similar). getenv sees all environment variables. I also did a phpinfo(); within the sensitve.config.php snippet, which showed me the whole environment when calling the nextcloud-url of my server.
<!--- see how your change affects other areas of the code, etc. -->
- Shouldn't affect anything, btw. you need to effectively change /etc/php7/php-fpm.d/www2.conf like said above to take effect.

## Source / References:
- I asked @aptalca on discord, he said I should write an issue, I decided for a PR
