### PR TITLE
Remove recursive permission commands from base

### DIFF
--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -30,12 +30,3 @@ sed -i "s#group = nobody.*#group = abc#g" /etc/php7/php-fpm.d/www.conf
 	printf "; Edit this file to override www.conf and php-fpm.conf directives and restart the container\\n\\n; Pool name\\n[www]\\n\\n" > /config/php/www2.conf
 # copy user www2.conf to image
 cp /config/php/www2.conf /etc/php7/php-fpm.d/www2.conf
-
-# permissions
-chown -R abc:abc \
-	/config \
-	/var/lib/nginx \
-	/var/tmp/nginx
-chmod -R g+w \
-	/config/{nginx,www}
-chmod -R 644 /etc/logrotate.d


### PR DESCRIPTION
Related: https://github.com/linuxserver/docker-letsencrypt/pull/385 not the same solution, but should achieve a similar goal.

Would need to be separately applied to other containers that use this base but still recursively apply permissions.