### PR TITLE
Auto number of worker processes

### DIFF
--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -1,7 +1,7 @@
 ## Version 2018/08/16 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx.conf
 
 user abc;
-worker_processes 4;
+worker_processes auto;
 pid /run/nginx.pid;
 include /etc/nginx/modules/*.conf;
 


### PR DESCRIPTION
## Description:

Set the number workers automatically based on the number of available cores. 

## Benefits of this PR and context:

This allows NGINX to better take advantage of multiple cores, or tune down in constrained environments.

A re-implementation of https://github.com/linuxserver/docker-baseimage-alpine-nginx/pull/53, without the connections change. Hoping re-opening the PR re-opens the discussion.

## How Has This Been Tested?

## Source / References:

https://nginx.org/en/docs/ngx_core_module.html#worker_processes
