### PR TITLE
phpfcgi: fix regex to solve that slash is forwarded before params which causes 404

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -18,7 +18,7 @@ server {
 	}
 
 	location ~ [^/]\.php(/|$) {
-	    fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+	    	fastcgi_split_path_info ^(.+?\.php)(/.*)$;
 		# With php5-cgi alone:
 		fastcgi_pass 127.0.0.1:9000;
 		# With php5-fpm:

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -17,8 +17,8 @@ server {
 		try_files $uri $uri/ /index.html /index.php?$args =404;
 	}
 
-	location ~ \.php$ {
-		fastcgi_split_path_info ^(.+\.php)(/.+)$;
+	location ~ [^/]\.php(/|$) {
+	    fastcgi_split_path_info ^(.+?\.php)(/.*)$;
 		# With php5-cgi alone:
 		fastcgi_pass 127.0.0.1:9000;
 		# With php5-fpm:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number>, in the body of the PR commit message   -->
<!---  You have included links to any files/patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-alpine-nginx/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Edit regex of `fastcgi_split_path_info` in nginx default config

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Before the edit, slash was forwarded before params of PHP GET requests. This caused 404. The PR fixes it.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with my personal PHP project with the same setup but the config files.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
See [here](https://stackoverflow.com/questions/39738630)