### PR TITLE
enable brotli compression in nginx defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN \
 	logrotate \
 	nano \
 	nginx \
+	nginx-mod-http-brotli \
 	openssl \
 	php7 \
 	php7-fileinfo \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -10,6 +10,7 @@ RUN \
 	logrotate \
 	nano \
 	nginx \
+	nginx-mod-http-brotli \
 	openssl \
 	php7 \
 	php7-fileinfo \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -10,6 +10,7 @@ RUN \
 	logrotate \
 	nano \
 	nginx \
+	nginx-mod-http-brotli \
 	openssl \
 	php7 \
 	php7-fileinfo \

--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -53,6 +53,16 @@ http {
 	# gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
 	##
+	# brotli Settings
+	##
+
+	brotli on;
+
+	# brotli_comp_level 5;
+	# brotli_static on;
+	# brotli_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml application/x-font-ttf image/vnd.microsoft.icon application/x-font-opentype font/eot application/vnd.ms-fontobject application/javascript font/otf application/xhtml+xml application/x-font-truetype image/x-icon font/opentype image/x-win-bitmap;
+
+	##
 	# nginx-naxsi config
 	##
 	# Uncomment it if you installed nginx-naxsi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-alpine-nginx/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

> 4. Readme is auto generated from readme-vars.yml, make your changes there

This repos `readme-vars.yml` is missing the changelog so no changes made there.

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Enabled brotli compression

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Brotli is for the most part a straight up replacement for gzip in modern browsers. So it makes sense to enable it here, in the same place that gzip is enabled, instead of in each individual downstream container.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
~~It has not.~~
This morning I tested it on my arm64 box. The brotli compression looks like it's working fine.

![chrome_gQk6QehKm9D9s2fQFLa7Xgkghh7HsfCn](https://user-images.githubusercontent.com/1653976/117180402-61f15080-ad91-11eb-9537-d50858899f0e.png)

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
