### PR TITLE
Update nginx.conf for reverse proxy use

### DIFF
--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -35,7 +35,11 @@ http {
 	# Logging Settings
 	##
 
-	access_log /config/log/nginx/access.log;
+	log_format proxy '$remote_addr - $remote_user [$time_local] '
+		'"$request" $status $body_bytes_sent '
+		'"$http_referer" "$http_user_agent" "$x_forwarded_for"';
+
+	access_log /config/log/nginx/access.log proxy;
 	error_log /config/log/nginx/error.log;
 
 	##


### PR DESCRIPTION
For services deployed behind reverse proxies (Traefik, SWAG, etc.), the access log will only show the IP of the proxy, making implementing fail2ban controls impossible.  This change adds $x_forwarded_for to the access log, so that it can be used.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-alpine-nginx/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
For services deployed behind reverse proxies (Traefik, SWAG, etc.), the access log will only show the IP of the proxy, making implementing fail2ban controls impossible.  This change adds $x_forwarded_for to the access log, so that it can be used.

A custom log_format "proxy" is specified in the docker packaged default nginx.conf file, and applied to the access.log file. This format differs from the nginx default only in that it adds the $x_forwarded_for field in quotations a the end of the logging string.

Example fail2ban filter:
```
[Definition]
failregex = ^.*1.1" 4[0-9]{2}.*"<HOST>"$
```

## Benefits of this PR and context:
Without this change, deploying images based on the base will need downstream config changes to support fail2ban control behind a reverse proxy, leading to additional steps. As the change does not change the default logging output, should have zero impact on users with the default config, nor will it impact images already deployed.

## How Has This Been Tested?
Changes tested using linuxserver/bookstack docker image and manual changes to logging config