### PR TITLE
Replace slow chowns with faster find with xargs

### DIFF
--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -37,10 +37,13 @@ if [ ! -e /etc/nginx/conf.d ]; then
 fi
 
 # permissions
-chown -R abc:abc \
-    /config \
-    /var/lib/nginx \
-    /var/tmp/nginx
+find /var/lib/nginx \
+    -not -group abc -not -user abc -print0 | xargs -P 0 -0 --no-run-if-empty chown --no-dereference abc:abc
+find /config \
+    -not -group abc -not -user abc -print0 | xargs -P 0 -0 --no-run-if-empty chown --no-dereference abc:abc
+find /var/tmp/nginx \
+    -not -group abc -not -user abc -print0 | xargs -P 0 -0 --no-run-if-empty chown --no-dereference abc:abc
+
 chmod -R g+w \
     /config/{nginx,www}
 chmod -R 644 /etc/logrotate.d

--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -36,14 +36,11 @@ if [ ! -e /etc/nginx/conf.d ]; then
     ln -s /etc/nginx/http.d /etc/nginx/conf.d
 fi
 
-# permissions
-find /var/lib/nginx \
-    -not -group abc -not -user abc -print0 | xargs -P 0 -0 --no-run-if-empty chown --no-dereference abc:abc
-find /config \
-    -not -group abc -not -user abc -print0 | xargs -P 0 -0 --no-run-if-empty chown --no-dereference abc:abc
-find /var/tmp/nginx \
+# permissions
+find /config /var/lib/nginx /var/tmp/nginx \
     -not -group abc -not -user abc -print0 | xargs -P 0 -0 --no-run-if-empty chown --no-dereference abc:abc
 
-chmod -R g+w \
-    /config/{nginx,www}
+find /config/nginx /config/www \
+    -not -type l -not -perm -g=w -print0 | xargs -P 0 -0 --no-run-if-empty chmod g+w
+
 chmod -R 644 /etc/logrotate.d


### PR DESCRIPTION
Improves startup times and closes  https://github.com/linuxserver/docker-nextcloud/issues/181  

------------------------------

 - [x ] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-alpine-nginx/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
The recursive chown operation in container startup is slow and inefficient. With a large number of files in there it takes several minutes.  This is because chown blindly writes to file metadata regardless of what's already in there.  It's much faster to first find files with wrong ownership and then individually chown them. 

This patch switches from `chown -R` to `find ... | xargs ... chown`. 

## Benefits of this PR and context:
It reduces container startup time for all users. This is particularly a problem for the docker-nextcloud project because it works with large filesystems...  but really anything that inherits this base is a lot slower than it could be.

## How Has This Been Tested?

I and one other user tested this by replacing the scripts in custom docker builds of our own. See https://github.com/linuxserver/docker-nextcloud/issues/181  for details.

