### PR TITLE
Disable server tokens

### DIFF
--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -1,4 +1,4 @@
-## Version 2021/06/15 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx.conf
+## Version 2021/10/24 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx.conf
 
 user abc;
 worker_processes 4;


### PR DESCRIPTION
## Description:

Disable nginx's server tokens (the version in the `Server` header)

## Benefits of this PR and context:

This avoids unnecessary information exposure.

Hiding the `Server` header altogether on nginx is notoriously difficult, but at least hiding the version hides some information which can be very useful in a security context.

## How Has This Been Tested?

Manually making the change and testing that the nginx version goes.

## Source / References:

https://nginx.org/en/docs/http/ngx_http_core_module.html#server_tokens