### PR TITLE
Base fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,3 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 80 443
-VOLUME /config

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,17 @@ RUN \
   echo 'fastcgi_param  SERVER_NAME        $host; # Send HTTP_HOST as SERVER_NAME. If HTTP_HOST is blank, send the value of server_name from nginx (default is `_`)' >> \
     /etc/nginx/fastcgi_params && \
   rm -f /etc/nginx/http.d/default.conf && \
+  echo "**** configure php ****" && \
+  ln -s /usr/bin/php8 /usr/bin/php && \
+  sed -i "s#;error_log = log/php8/error.log.*#error_log = /config/log/php/error.log#g" \
+    /etc/php8/php-fpm.conf && \
+  sed -i "s#user = nobody.*#user = abc#g" \
+    /etc/php8/php-fpm.d/www.conf && \
+  sed -i "s#group = nobody.*#group = abc#g" \
+    /etc/php8/php-fpm.d/www.conf && \
   echo "**** fix logrotate ****" && \
-  sed -i "s#/var/log/messages {}.*# #g" /etc/logrotate.conf && \
+  sed -i "s#/var/log/messages {}.*# #g" \
+    /etc/logrotate.conf && \
   sed -i 's#/usr/sbin/logrotate /etc/logrotate.conf#/usr/sbin/logrotate /etc/logrotate.conf -s /config/log/logrotate.status#g' \
     /etc/periodic/daily/logrotate
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -42,4 +42,3 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 80 443
-VOLUME /config

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -32,8 +32,17 @@ RUN \
   echo 'fastcgi_param  SERVER_NAME        $host; # Send HTTP_HOST as SERVER_NAME. If HTTP_HOST is blank, send the value of server_name from nginx (default is `_`)' >> \
     /etc/nginx/fastcgi_params && \
   rm -f /etc/nginx/http.d/default.conf && \
+  echo "**** configure php ****" && \
+  ln -s /usr/bin/php8 /usr/bin/php && \
+  sed -i "s#;error_log = log/php8/error.log.*#error_log = /config/log/php/error.log#g" \
+    /etc/php8/php-fpm.conf && \
+  sed -i "s#user = nobody.*#user = abc#g" \
+    /etc/php8/php-fpm.d/www.conf && \
+  sed -i "s#group = nobody.*#group = abc#g" \
+    /etc/php8/php-fpm.d/www.conf && \
   echo "**** fix logrotate ****" && \
-  sed -i "s#/var/log/messages {}.*# #g" /etc/logrotate.conf && \
+  sed -i "s#/var/log/messages {}.*# #g" \
+    /etc/logrotate.conf && \
   sed -i 's#/usr/sbin/logrotate /etc/logrotate.conf#/usr/sbin/logrotate /etc/logrotate.conf -s /config/log/logrotate.status#g' \
     /etc/periodic/daily/logrotate
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -42,4 +42,3 @@ COPY root/ /
 
 # ports and volumes
 EXPOSE 80 443
-VOLUME /config

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -32,8 +32,17 @@ RUN \
   echo 'fastcgi_param  SERVER_NAME        $host; # Send HTTP_HOST as SERVER_NAME. If HTTP_HOST is blank, send the value of server_name from nginx (default is `_`)' >> \
     /etc/nginx/fastcgi_params && \
   rm -f /etc/nginx/http.d/default.conf && \
+  echo "**** configure php ****" && \
+  ln -s /usr/bin/php8 /usr/bin/php && \
+  sed -i "s#;error_log = log/php8/error.log.*#error_log = /config/log/php/error.log#g" \
+    /etc/php8/php-fpm.conf && \
+  sed -i "s#user = nobody.*#user = abc#g" \
+    /etc/php8/php-fpm.d/www.conf && \
+  sed -i "s#group = nobody.*#group = abc#g" \
+    /etc/php8/php-fpm.d/www.conf && \
   echo "**** fix logrotate ****" && \
-  sed -i "s#/var/log/messages {}.*# #g" /etc/logrotate.conf && \
+  sed -i "s#/var/log/messages {}.*# #g" \
+    /etc/logrotate.conf && \
   sed -i 's#/usr/sbin/logrotate /etc/logrotate.conf#/usr/sbin/logrotate /etc/logrotate.conf -s /config/log/logrotate.status#g' \
     /etc/periodic/daily/logrotate
 

--- a/root/etc/cont-init.d/12-samples
+++ b/root/etc/cont-init.d/12-samples
@@ -1,21 +1,34 @@
 #!/usr/bin/with-contenv bash
 
 # remove old samples
-find /config/nginx/ -name "*.conf.sample" -type f -delete
+find /config/nginx/ \
+    -name "*.conf.sample" \
+    -type f \
+    -delete
 
-# copy new samples
-cp \
-    /defaults/nginx/*.conf.sample \
-    /config/nginx/
-cp \
-    /defaults/nginx/http-confs/*.conf.sample \
-    /config/nginx/http-confs/
-cp \
-    /defaults/nginx/location-confs/*.conf.sample \
-    /config/nginx/location-confs/
-cp \
-    /defaults/nginx/server-confs/*.conf.sample \
-    /config/nginx/server-confs/
-cp \
-    /defaults/nginx/site-confs/*.conf.sample \
-    /config/nginx/site-confs/
+# copy new samples
+find /defaults/nginx/ \
+    -maxdepth 1 \
+    -name "*.conf.sample" \
+    -type f \
+    -exec cp "{}" /config/nginx/ +
+find /defaults/nginx/http-confs/ \
+    -maxdepth 1 \
+    -name "*.conf.sample" \
+    -type f \
+    -exec cp "{}" /config/nginx/http-confs/ +
+find /defaults/nginx/location-confs/ \
+    -maxdepth 1 \
+    -name "*.conf.sample" \
+    -type f \
+    -exec cp "{}" /config/nginx/location-confs/ +
+find /defaults/nginx/server-confs/ \
+    -maxdepth 1 \
+    -name "*.conf.sample" \
+    -type f \
+    -exec cp "{}" /config/nginx/server-confs/ +
+find /defaults/nginx/site-confs/ \
+    -maxdepth 1 \
+    -name "*.conf.sample" \
+    -type f \
+    -exec cp "{}" /config/nginx/site-confs/ +

--- a/root/etc/cont-init.d/12-samples
+++ b/root/etc/cont-init.d/12-samples
@@ -12,23 +12,31 @@ find /defaults/nginx/ \
     -name "*.conf.sample" \
     -type f \
     -exec cp "{}" /config/nginx/ +
-find /defaults/nginx/http-confs/ \
-    -maxdepth 1 \
-    -name "*.conf.sample" \
-    -type f \
-    -exec cp "{}" /config/nginx/http-confs/ +
-find /defaults/nginx/location-confs/ \
-    -maxdepth 1 \
-    -name "*.conf.sample" \
-    -type f \
-    -exec cp "{}" /config/nginx/location-confs/ +
-find /defaults/nginx/server-confs/ \
-    -maxdepth 1 \
-    -name "*.conf.sample" \
-    -type f \
-    -exec cp "{}" /config/nginx/server-confs/ +
-find /defaults/nginx/site-confs/ \
-    -maxdepth 1 \
-    -name "*.conf.sample" \
-    -type f \
-    -exec cp "{}" /config/nginx/site-confs/ +
+
+[[ -d /defaults/nginx/http-confs/ ]] &&
+    find /defaults/nginx/http-confs/ \
+        -maxdepth 1 \
+        -name "*.conf.sample" \
+        -type f \
+        -exec cp "{}" /config/nginx/http-confs/ +
+
+[[ -d /defaults/nginx/location-confs/ ]] &&
+    find /defaults/nginx/location-confs/ \
+        -maxdepth 1 \
+        -name "*.conf.sample" \
+        -type f \
+        -exec cp "{}" /config/nginx/location-confs/ +
+
+[[ -d /defaults/nginx/server-confs/ ]] &&
+    find /defaults/nginx/server-confs/ \
+        -maxdepth 1 \
+        -name "*.conf.sample" \
+        -type f \
+        -exec cp "{}" /config/nginx/server-confs/ +
+
+[[ -d /defaults/nginx/site-confs/ ]] &&
+    find /defaults/nginx/site-confs/ \
+        -maxdepth 1 \
+        -name "*.conf.sample" \
+        -type f \
+        -exec cp "{}" /config/nginx/site-confs/ +

--- a/root/etc/cont-init.d/13-nginx
+++ b/root/etc/cont-init.d/13-nginx
@@ -25,6 +25,7 @@ if ! grep -q 'PARAMETERS' "/config/nginx/dhparams.pem"; then
 fi
 
 # Set resolver, ignore ipv6 addresses
+touch /config/nginx/http-confs/resolver.conf
 if ! grep -q 'resolver' /config/nginx/http-confs/resolver.conf; then
     RESOLVERRAW=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
     for i in ${RESOLVERRAW}; do
@@ -42,6 +43,7 @@ if ! grep -q 'resolver' /config/nginx/http-confs/resolver.conf; then
 fi
 
 # Set worker_processes
+touch /config/nginx/worker_processes.conf
 if ! grep -q 'worker_processes' /config/nginx/worker_processes.conf; then
     WORKER_PROCESSES=$(nproc)
     echo "Setting worker_processes to ${WORKER_PROCESSES}"

--- a/root/etc/cont-init.d/14-php
+++ b/root/etc/cont-init.d/14-php
@@ -1,22 +1,11 @@
 #!/usr/bin/with-contenv bash
 
-# symlink php binary
-[[ ! -e /usr/bin/php ]] && \
-    ln -s /usr/bin/php8 /usr/bin/php
-
 # create local php.ini if it doesn't exist, set local timezone
 [[ ! -f /config/php/php-local.ini ]] && \
     printf "; Edit this file to override php.ini directives and restart the container\\n\\ndate.timezone = %s\\n" "$TZ" > /config/php/php-local.ini
 
 # copy user php-local.ini to image
 cp /config/php/php-local.ini /etc/php8/conf.d/php-local.ini
-
-#fix php-fpm log location
-sed -i "s#;error_log = log/php8/error.log.*#error_log = /config/log/php/error.log#g" /etc/php8/php-fpm.conf
-
-#fix php-fpm user
-sed -i "s#user = nobody.*#user = abc#g" /etc/php8/php-fpm.d/www.conf
-sed -i "s#group = nobody.*#group = abc#g" /etc/php8/php-fpm.d/www.conf
 
 # create override for www.conf if it doesn't exist
 [[ ! -f /config/php/www2.conf ]] && \


### PR DESCRIPTION
Follow up from #84 

Use find to cp files 
This avoids a log message if the source folder is empty

touch resolver and worker_processes before use 
this prevents logging warnings about the files not existing

Per discussion on Discord: remove `/config` volume definition from Dockerfile(s)