### PR TITLE
Extensions

### DIFF
--- a/root/etc/cont-init.d/12-samples
+++ b/root/etc/cont-init.d/12-samples
@@ -13,30 +13,34 @@ find /defaults/nginx/ \
     -type f \
     -exec cp "{}" /config/nginx/ +
 
-[[ -d /defaults/nginx/http-confs/ ]] &&
+if [[ -d /defaults/nginx/http-confs/ ]]; then
     find /defaults/nginx/http-confs/ \
         -maxdepth 1 \
         -name "*.conf.sample" \
         -type f \
         -exec cp "{}" /config/nginx/http-confs/ +
+fi
 
-[[ -d /defaults/nginx/location-confs/ ]] &&
+if [[ -d /defaults/nginx/location-confs/ ]]; then
     find /defaults/nginx/location-confs/ \
         -maxdepth 1 \
         -name "*.conf.sample" \
         -type f \
         -exec cp "{}" /config/nginx/location-confs/ +
+fi
 
-[[ -d /defaults/nginx/server-confs/ ]] &&
+if [[ -d /defaults/nginx/server-confs/ ]]; then
     find /defaults/nginx/server-confs/ \
         -maxdepth 1 \
         -name "*.conf.sample" \
         -type f \
         -exec cp "{}" /config/nginx/server-confs/ +
+fi
 
-[[ -d /defaults/nginx/site-confs/ ]] &&
+if [[ -d /defaults/nginx/site-confs/ ]]; then
     find /defaults/nginx/site-confs/ \
         -maxdepth 1 \
         -name "*.conf.sample" \
         -type f \
         -exec cp "{}" /config/nginx/site-confs/ +
+fi

--- a/root/etc/cont-init.d/13-nginx
+++ b/root/etc/cont-init.d/13-nginx
@@ -1,10 +1,12 @@
 #!/usr/bin/with-contenv bash
 
 # copy default config files if they don't exist
-[[ ! -f /config/nginx/nginx.conf ]] && \
+if [[ ! -f /config/nginx/nginx.conf ]]; then
     cp /defaults/nginx/nginx.conf.sample /config/nginx/nginx.conf
-[[ ! -f /config/nginx/site-confs/default.conf ]] && \
+fi
+if [[ ! -f /config/nginx/site-confs/default.conf ]]; then
     cp /defaults/nginx/site-confs/default.conf.sample /config/nginx/site-confs/default.conf
+fi
 
 # copy index.html if no index file exists
 INDEX_EXISTS=false
@@ -14,12 +16,15 @@ for file in /config/www/index.*; do
         break
     fi
 done
-[[ ${INDEX_EXISTS} == false ]] && grep -Eq '^\s*index[^#]*index\.html' /config/nginx/**/*.conf && \
+if [[ ${INDEX_EXISTS} == false ]]; then
+    grep -Eq '^\s*index[^#]*index\.html' /config/nginx/**/*.conf
     cp /defaults/www/index.html /config/www/index.html
+fi
 
 # copy pre-generated dhparams or generate if needed
-[[ ! -f /config/nginx/dhparams.pem ]] && \
+if [[ ! -f /config/nginx/dhparams.pem ]]; then
     cp /defaults/nginx/dhparams.pem /config/nginx/dhparams.pem
+fi
 if ! grep -q 'PARAMETERS' "/config/nginx/dhparams.pem"; then
     curl -o /config/nginx/dhparams.pem -L "https://ssl-config.mozilla.org/ffdhe4096.txt"
 fi

--- a/root/etc/cont-init.d/13-nginx
+++ b/root/etc/cont-init.d/13-nginx
@@ -8,6 +8,9 @@ if [[ ! -f /config/nginx/site-confs/default.conf ]]; then
     cp /defaults/nginx/site-confs/default.conf.sample /config/nginx/site-confs/default.conf
 fi
 
+# force nginx.conf to include site-confs/*.conf instead of site-confs/*
+sed -i -E "s#^(\s*)include /config/nginx/site-confs/\*;#\1include /config/nginx/site-confs/\*.conf;#" /config/nginx/nginx.conf
+
 # copy index.html if no index file exists
 INDEX_EXISTS=false
 for file in /config/www/index.*; do

--- a/root/etc/cont-init.d/14-php
+++ b/root/etc/cont-init.d/14-php
@@ -1,15 +1,17 @@
 #!/usr/bin/with-contenv bash
 
 # create local php.ini if it doesn't exist, set local timezone
-[[ ! -f /config/php/php-local.ini ]] && \
+if [[ ! -f /config/php/php-local.ini ]]; then
     printf "; Edit this file to override php.ini directives and restart the container\\n\\ndate.timezone = %s\\n" "$TZ" > /config/php/php-local.ini
+fi
 
 # copy user php-local.ini to image
 cp /config/php/php-local.ini /etc/php8/conf.d/php-local.ini
 
 # create override for www.conf if it doesn't exist
-[[ ! -f /config/php/www2.conf ]] && \
+if [[ ! -f /config/php/www2.conf ]]; then
     printf "; Edit this file to override www.conf and php-fpm.conf directives and restart the container\\n\\n; Pool name\\n[www]\\n\\n" > /config/php/www2.conf
+fi
 
 # copy user www2.conf to image
 cp /config/php/www2.conf /etc/php8/php-fpm.d/www2.conf

--- a/root/etc/cont-init.d/85-version-checks
+++ b/root/etc/cont-init.d/85-version-checks
@@ -1,5 +1,6 @@
 #!/usr/bin/with-contenv bash
 
+# detect nginx configs with dates not matching the provided sample files
 active_confs=$(find /config/nginx/ -name "*.conf" -type f 2>/dev/null)
 
 for i in ${active_confs}; do
@@ -16,4 +17,15 @@ if [ -n "${active_confs_changed}" ]; then
     echo "**** You should compare the following files to the samples in the same folder and update them. ****"
     echo "**** Use the link at the top of the file to view the changelog. ****"
     echo -e "${active_confs_changed}"
+fi
+
+# detect site-confs with wrong extension
+site_confs_wrong_ext=$(find /config/nginx/site-confs/ -type f -not -name "*.conf" -not -name "*.conf.sample" 2>/dev/null)
+
+if [ -n "${site_confs_wrong_ext}" ]; then
+    echo "**** The following site-confs have extensions other than .conf ****"
+    echo "**** This may be due to user customization. ****"
+    echo "**** You should review the files and rename them to use the .conf extension or remove them. ****"
+    echo "**** nginx.conf will only include site-confs with the .conf extension. ****"
+    echo -e "${site_confs_wrong_ext}"
 fi


### PR DESCRIPTION
Depends on #92 (merge first)

force nginx.conf to include `site-confs/*.conf` instead of `site-confs/*`

detect site-confs with wrong extension