### PR TITLE
Add listen on 443 back to default site

### DIFF
--- a/root/defaults/nginx/site-confs/default.conf.sample
+++ b/root/defaults/nginx/site-confs/default.conf.sample
@@ -4,6 +4,9 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
     server_name _;
 
     set $root /app/www/public;


### PR DESCRIPTION
https://github.com/linuxserver/docker-baseimage-alpine-nginx/blob/3.14/root/defaults/default actually does have 443 (https) enabled and listening by default.
