### PR TITLE
Add default_server

### DIFF
--- a/root/defaults/nginx/site-confs/default.conf.sample
+++ b/root/defaults/nginx/site-confs/default.conf.sample
@@ -4,8 +4,8 @@ server {
     listen 80 default_server;
     listen [::]:80 default_server;
 
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl http2 default_server;
+    listen [::]:443 ssl http2 default_server;
 
     server_name _;
 


### PR DESCRIPTION
Related:

https://github.com/linuxserver/docker-xbackbone/pull/15
https://github.com/linuxserver/docker-snapdrop/pull/10
https://github.com/linuxserver/docker-phpmyadmin/pull/21
https://github.com/linuxserver/docker-grav/pull/20
https://github.com/linuxserver/docker-dokuwiki/pull/51
https://github.com/linuxserver/docker-bookstack/pull/137

Same premise, but not the exact same change:
https://github.com/linuxserver/reverse-proxy-confs/pull/492
proxy confs actually should NOT include `default_server` since it should be in the `site-confs/default.conf`