### PR TITLE
Fix changelog URL and date

### DIFF
--- a/root/defaults/nginx/nginx.conf.sample
+++ b/root/defaults/nginx/nginx.conf.sample
@@ -1,4 +1,4 @@
-## Version 2022/08/05 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx/nginx.conf.sample
+## Version 2022/08/16 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx/nginx.conf.sample
 
 ### Based on alpine defaults
 # https://git.alpinelinux.org/aports/tree/main/nginx/nginx.conf?h=3.15-stable

--- a/root/defaults/nginx/nginx.conf.sample
+++ b/root/defaults/nginx/nginx.conf.sample
@@ -1,4 +1,4 @@
-## Version 2022/08/05 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx.conf.sample
+## Version 2022/08/05 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx/nginx.conf.sample
 
 ### Based on alpine defaults
 # https://git.alpinelinux.org/aports/tree/main/nginx/nginx.conf?h=3.15-stable

--- a/root/defaults/nginx/site-confs/default.conf.sample
+++ b/root/defaults/nginx/site-confs/default.conf.sample
@@ -1,4 +1,4 @@
-## Version 2022/08/05 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx/site-confs/default.conf.sample
+## Version 2022/10/04 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx/site-confs/default.conf.sample
 
 server {
     listen 80 default_server;

--- a/root/defaults/nginx/ssl.conf.sample
+++ b/root/defaults/nginx/ssl.conf.sample
@@ -1,4 +1,4 @@
-## Version 2022/08/05 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx/ssl.conf.sample
+## Version 2022/08/20 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx/ssl.conf.sample
 
 ### Mozilla Recommendations
 # generated 2022-08-05, Mozilla Guideline v5.6, nginx 1.17.7, OpenSSL 1.1.1k, intermediate configuration

--- a/root/defaults/nginx/ssl.conf.sample
+++ b/root/defaults/nginx/ssl.conf.sample
@@ -1,4 +1,4 @@
-## Version 2022/08/05 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/ssl.conf.sample
+## Version 2022/08/05 - Changelog: https://github.com/linuxserver/docker-baseimage-alpine-nginx/commits/master/root/defaults/nginx/ssl.conf.sample
 
 ### Mozilla Recommendations
 # generated 2022-08-05, Mozilla Guideline v5.6, nginx 1.17.7, OpenSSL 1.1.1k, intermediate configuration


### PR DESCRIPTION
Fix changelog URL and date. URL broke when folder directory changed.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-alpine-nginx/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
The changelog URL broke after a folder structure change. Files are now in:
`/root/defaults/nginx/nginx.conf.sample`
`/root/defaults/nginx/ssl.conf.sample`
instead of:
`/root/defaults/nginx.conf.sample`
`/root/defaults/ssl.conf.sample`

The date is also wrong so I changed it to when the last "real" commit was, does this commit count as a change?

## Benefits of this PR and context:
It fixes the link. No more 404.
And date is now correct.

## How Has This Been Tested?
I just clicked the link, I have no idea if this changes something somewhere else.
