### PR TITLE
Set perms on big dirs much faster

### DIFF
--- a/root/etc/cont-init.d/20-permissions
+++ b/root/etc/cont-init.d/20-permissions
@@ -5,8 +5,10 @@ chown -R abc:abc \
     /config \
     /var/lib/nginx \
     /var/tmp/nginx
-chmod -R g+w \
-    /config/{nginx,www}
+
+# Potentially big dirs: Set permissions in parallel and only writing to inodes that need it
+find /config/{nginx,www} -print0 | xargs -P "$(nproc)" -I {} -0 chmod g+w {}
+
 chmod -R 644 /etc/logrotate.d
 if [ -f "/config/log/logrotate.status" ]; then
     chmod 600 /config/log/logrotate.status


### PR DESCRIPTION
 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-alpine-nginx/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

## Description:

replace chmod -R on potentially very large `/config/{nginx,www}`directories with `find | xargs | chmod` so it runs 1) in parallel and 2) only writing to the inodes that need it. This is much faster than chmod, which performs writes on every file and directory checked.



## Benefits of this PR and context:

Closes #107 .

## How Has This Been Tested?

Manually timed the chown command vs replacement against my own filesystem with 3137418 Inodes.

## Source / References:

Implementation taken from [linuxserver/docker-bookstack](https://github.com/linuxserver/docker-bookstack/pull/102/files#diff-18bed53c5df14db4abf947a2d38ac6839c81e2b594cfb9e47dff912c9d4f06fb)