### PR TITLE
rm certs when regenerating

### DIFF
--- a/root/etc/cont-init.d/15-keygen
+++ b/root/etc/cont-init.d/15-keygen
@@ -5,5 +5,8 @@ if [[ -f /config/keys/cert.key && -f /config/keys/cert.crt ]]; then
     echo "using keys found in /config/keys"
 else
     echo "generating self-signed keys in /config/keys, you can replace these with your own keys if required"
+    rm -f \
+        /config/keys/cert.key \
+        /config/keys/cert.crt || true
     openssl req -new -x509 -days 3650 -nodes -out /config/keys/cert.crt -keyout /config/keys/cert.key -subj "$SUBJECT"
 fi


### PR DESCRIPTION
Possible fix for

```
swag  | writing new private key to '/config/keys/cert.key'
swag  | req: Can't open "/config/keys/cert.key" for writing, No such file or directory
swag  | cont-init: info: /etc/cont-init.d/15-keygen exited 1
```