### PR TITLE
Symlink php and install composer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,20 @@ RUN \
     nginx \
     openssl \
     php82 \
+    php82-ctype \
+    php82-curl \
     php82-fileinfo \
     php82-fpm \
+    php82-iconv \
     php82-json \
     php82-mbstring \
     php82-openssl \
+    php82-phar \
     php82-session \
     php82-simplexml \
     php82-xml \
     php82-xmlwriter \
+    php82-zip \
     php82-zlib && \
   echo "**** configure nginx ****" && \
   echo 'fastcgi_param  HTTP_PROXY         ""; # https://httpoxy.org/' >> \
@@ -34,6 +39,11 @@ RUN \
     /etc/nginx/fastcgi_params && \
   rm -f /etc/nginx/conf.d/stream.conf && \
   rm -f /etc/nginx/http.d/default.conf && \
+  echo "**** guarantee correct php version is symlinked ****" && \
+  if [ "$(readlink /usr/bin/php)" != "php82" ]; then \
+    rm -rf /usr/bin/php && \
+    ln -s /usr/bin/php82 /usr/bin/php; \
+  fi && \
   echo "**** configure php ****" && \
   sed -i "s#;error_log = log/php82/error.log.*#error_log = /config/log/php/error.log#g" \
     /etc/php82/php-fpm.conf && \
@@ -41,6 +51,18 @@ RUN \
     /etc/php82/php-fpm.d/www.conf && \
   sed -i "s#group = nobody.*#group = abc#g" \
     /etc/php82/php-fpm.d/www.conf && \
+  echo "**** install php composer ****" && \
+  EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')" && \
+  php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+  ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")" && \
+  if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; then \
+      >&2 echo 'ERROR: Invalid installer checksum' && \
+      rm composer-setup.php && \
+      exit 1; \
+  fi && \
+  php composer-setup.php --install-dir=/usr/bin && \
+  rm composer-setup.php && \
+  ln -s /usr/bin/composer.phar /usr/bin/composer && \
   echo "**** fix logrotate ****" && \
   sed -i "s#/var/log/messages {}.*# #g" \
     /etc/logrotate.conf && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -13,15 +13,20 @@ RUN \
     nginx \
     openssl \
     php82 \
+    php82-ctype \
+    php82-curl \
     php82-fileinfo \
     php82-fpm \
+    php82-iconv \
     php82-json \
     php82-mbstring \
     php82-openssl \
+    php82-phar \
     php82-session \
     php82-simplexml \
     php82-xml \
     php82-xmlwriter \
+    php82-zip \
     php82-zlib && \
   echo "**** configure nginx ****" && \
   echo 'fastcgi_param  HTTP_PROXY         ""; # https://httpoxy.org/' >> \
@@ -34,6 +39,11 @@ RUN \
     /etc/nginx/fastcgi_params && \
   rm -f /etc/nginx/conf.d/stream.conf && \
   rm -f /etc/nginx/http.d/default.conf && \
+  echo "**** guarantee correct php version is symlinked ****" && \
+  if [ "$(readlink /usr/bin/php)" != "php82" ]; then \
+    rm -rf /usr/bin/php && \
+    ln -s /usr/bin/php82 /usr/bin/php; \
+  fi && \
   echo "**** configure php ****" && \
   sed -i "s#;error_log = log/php82/error.log.*#error_log = /config/log/php/error.log#g" \
     /etc/php82/php-fpm.conf && \
@@ -41,6 +51,18 @@ RUN \
     /etc/php82/php-fpm.d/www.conf && \
   sed -i "s#group = nobody.*#group = abc#g" \
     /etc/php82/php-fpm.d/www.conf && \
+  echo "**** install php composer ****" && \
+  EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')" && \
+  php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+  ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")" && \
+  if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; then \
+      >&2 echo 'ERROR: Invalid installer checksum' && \
+      rm composer-setup.php && \
+      exit 1; \
+  fi && \
+  php composer-setup.php --install-dir=/usr/bin && \
+  rm composer-setup.php && \
+  ln -s /usr/bin/composer.phar /usr/bin/composer && \
   echo "**** fix logrotate ****" && \
   sed -i "s#/var/log/messages {}.*# #g" \
     /etc/logrotate.conf && \


### PR DESCRIPTION
In Alpine 3.18

* php 8.2 DOES NOT create `/usr/bin/php` (only `/usr/bin/php82`)
* php 8.1 DOES create `/usr/bin/php` as a symlink to `/usr/bin/php81`

Some packages (like `composer`) in Alpine's package repositories depend on php 8.1, and others depend on php 8.2. Since their dependency versioning is inconsistent it will be simpler to permanently maintain our own symlink and include composer globally via a manual install.

Composer install borrowed from https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md which nicely includes a signature check. Symlinking `/usr/bin/composer.phar` to `/usr/bin/composer` for parity with Alpine's composer package.

Worth noting: This method of installing composer does not show composer in the SBOM