### PR TITLE
Adjust php timezone handling

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-php/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-php/run
@@ -1,9 +1,12 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+# set default timezone
+printf "date.timezone = %s\\n" "${TZ:-UTC}" >/etc/php82/conf.d/30_timezone.ini
+
 # create local php.ini if it doesn't exist, set local timezone
 if [[ ! -f /config/php/php-local.ini ]]; then
-    printf "; Edit this file to override php.ini directives\\n\\ndate.timezone = %s\\n" "$TZ" >/config/php/php-local.ini
+    printf "; Edit this file to override php.ini directives\\n\\n" >/config/php/php-local.ini
 fi
 
 # symlink user php-local.ini to image

--- a/root/etc/s6-overlay/s6-rc.d/init-php/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-php/run
@@ -11,7 +11,8 @@ fi
 
 # symlink user php-local.ini to image
 rm -rf /etc/php82/conf.d/php-local.ini
-ln -s /config/php/php-local.ini /etc/php82/conf.d/php-local.ini
+rm -rf /etc/php82/conf.d/zzz_php-local.ini
+ln -s /config/php/php-local.ini /etc/php82/conf.d/zzz_php-local.ini
 
 # create override for www.conf if it doesn't exist
 if [[ ! -f /config/php/www2.conf ]]; then


### PR DESCRIPTION
Set php timezone separately on every init 
Fallback to UTC if unset

Change php-local.ini symlink to ensure it is last 
