### PR TITLE
Add missing always to headers

### DIFF
--- a/root/defaults/nginx/ssl.conf.sample
+++ b/root/defaults/nginx/ssl.conf.sample
@@ -30,8 +30,8 @@ ssl_prefer_server_ciphers off;
 
 # Optional additional headers
 #add_header Cache-Control "no-transform" always;
-#add_header Content-Security-Policy "upgrade-insecure-requests; frame-ancestors 'self'";
-#add_header Permissions-Policy "interest-cohort=()";
+#add_header Content-Security-Policy "upgrade-insecure-requests; frame-ancestors 'self'" always;
+#add_header Permissions-Policy "interest-cohort=()" always;
 #add_header Referrer-Policy "same-origin" always;
 #add_header X-Content-Type-Options "nosniff" always;
 #add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
Closes https://github.com/linuxserver/docker-swag/issues/391

Ref: https://nginx.org/en/docs/http/ngx_http_headers_module.html

> If the `always` parameter is specified the specified field will be added regardless of the response code.

Tested and confirmed, no issues.