### PR TITLE
add nginx and php versions to baseimage tag

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -12,6 +12,93 @@ jobs:
       - name: External Trigger
         if: github.ref == 'refs/heads/master'
         run: |
-          echo "**** No external release, exiting ****"
-          echo "No external release, exiting" >> $GITHUB_STEP_SUMMARY
-          exit 0
+          if [ -n "${{ secrets.PAUSE_EXTERNAL_TRIGGER_BASEIMAGE_ALPINE_NGINX_MASTER }}" ]; then
+            echo "**** Github secret PAUSE_EXTERNAL_TRIGGER_BASEIMAGE_ALPINE_NGINX_MASTER is set; skipping trigger. ****"
+            echo "Github secret \`PAUSE_EXTERNAL_TRIGGER_BASEIMAGE_ALPINE_NGINX_MASTER\` is set; skipping trigger." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          echo "**** External trigger running off of master branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_BASEIMAGE_ALPINE_NGINX_MASTER\". ****"
+          echo "External trigger running off of master branch. To disable this trigger, set a Github secret named \`PAUSE_EXTERNAL_TRIGGER_BASEIMAGE_ALPINE_NGINX_MASTER\`" >> $GITHUB_STEP_SUMMARY
+          echo "**** Retrieving external version ****"
+          EXT_RELEASE=$(echo $(curl -sL http://dl-cdn.alpinelinux.org/alpine/v3.19/main/x86_64/APKINDEX.tar.gz | tar -xz -C /tmp && awk '/^P:'"nginx"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://')_$(curl -sL http://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz | tar -xz -C /tmp && awk '/^P:'"php83"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'))
+          if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
+            echo "**** Can't retrieve external version, exiting ****"
+            FAILURE_REASON="Can't retrieve external version for baseimage-alpine-nginx branch master"
+            GHA_TRIGGER_URL="https://github.com/linuxserver/docker-baseimage-alpine-nginx/actions/runs/${{ github.run_id }}"
+            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 16711680,
+              "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n**Trigger URL:** '"${GHA_TRIGGER_URL}"' \n"}],
+              "username": "Github Actions"}' ${{ secrets.DISCORD_WEBHOOK }}
+            exit 1
+          fi
+          EXT_RELEASE=$(echo ${EXT_RELEASE} | sed 's/[~,%@+;:/]//g')
+          echo "**** External version: ${EXT_RELEASE} ****"
+          echo "External version: ${EXT_RELEASE}" >> $GITHUB_STEP_SUMMARY
+          echo "**** Retrieving last pushed version ****"
+          image="linuxserver/baseimage-alpine-nginx"
+          tag="3.19"
+          token=$(curl -sX GET \
+            "https://ghcr.io/token?scope=repository%3Alinuxserver%2Fbaseimage-alpine-nginx%3Apull" \
+            | jq -r '.token')
+            multidigest=$(curl -s \
+              --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              --header "Authorization: Bearer ${token}" \
+              "https://ghcr.io/v2/${image}/manifests/${tag}" \
+              | jq -r 'first(.manifests[].digest)')
+            digest=$(curl -s \
+              --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              --header "Authorization: Bearer ${token}" \
+              "https://ghcr.io/v2/${image}/manifests/${multidigest}" \
+              | jq -r '.config.digest')
+          image_info=$(curl -sL \
+            --header "Authorization: Bearer ${token}" \
+            "https://ghcr.io/v2/${image}/blobs/${digest}")
+          if [[ $(echo $image_info | jq -r '.container_config') == "null" ]]; then
+            image_info=$(echo $image_info | jq -r '.config')
+          else
+            image_info=$(echo $image_info | jq -r '.container_config')
+          fi
+          IMAGE_RELEASE=$(echo ${image_info} | jq -r '.Labels.build_version' | awk '{print $3}')
+          IMAGE_VERSION=$(echo ${IMAGE_RELEASE} | awk -F'-ls' '{print $1}')
+          if [ -z "${IMAGE_VERSION}" ]; then
+            echo "**** Can't retrieve last pushed version, exiting ****"
+            FAILURE_REASON="Can't retrieve last pushed version for baseimage-alpine-nginx tag 3.19"
+            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 16711680,
+              "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n"}],
+              "username": "Github Actions"}' ${{ secrets.DISCORD_WEBHOOK }}
+            exit 1
+          fi
+          echo "**** Last pushed version: ${IMAGE_VERSION} ****"
+          echo "Last pushed version: ${IMAGE_VERSION}" >> $GITHUB_STEP_SUMMARY
+          if [ "${EXT_RELEASE}" == "${IMAGE_VERSION}" ]; then
+            echo "**** Version ${EXT_RELEASE} already pushed, exiting ****"
+            echo "Version ${EXT_RELEASE} already pushed, exiting" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          elif [ $(curl -s https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-baseimage-alpine-nginx/job/master/lastBuild/api/json | jq -r '.building') == "true" ]; then
+            echo "**** New version ${EXT_RELEASE} found; but there already seems to be an active build on Jenkins; exiting ****"
+            echo "New version ${EXT_RELEASE} found; but there already seems to be an active build on Jenkins; exiting" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          else
+            echo "**** New version ${EXT_RELEASE} found; old version was ${IMAGE_VERSION}. Triggering new build ****"
+            echo "New version ${EXT_RELEASE} found; old version was ${IMAGE_VERSION}. Triggering new build" >> $GITHUB_STEP_SUMMARY
+            response=$(curl -iX POST \
+              https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-baseimage-alpine-nginx/job/master/buildWithParameters?PACKAGE_CHECK=false \
+              --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }} | grep -i location | sed "s|^[L|l]ocation: \(.*\)|\1|")
+            echo "**** Jenkins job queue url: ${response%$'\r'} ****"
+            echo "**** Sleeping 10 seconds until job starts ****"
+            sleep 10
+            buildurl=$(curl -s "${response%$'\r'}api/json" | jq -r '.executable.url')
+            buildurl="${buildurl%$'\r'}"
+            echo "**** Jenkins job build url: ${buildurl} ****"
+            echo "Jenkins job build url: ${buildurl}" >> $GITHUB_STEP_SUMMARY
+            echo "**** Attempting to change the Jenkins job description ****"
+            curl -iX POST \
+              "${buildurl}submitDescription" \
+              --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }} \
+              --data-urlencode "description=GHA external trigger https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              --data-urlencode "Submit=Submit"
+            echo "**** Notifying Discord ****"
+            TRIGGER_REASON="A version change was detected for baseimage-alpine-nginx tag 3.19. Old version:${IMAGE_VERSION} New version:${EXT_RELEASE}"
+            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
+              "description": "**Build Triggered** \n**Reason:** '"${TRIGGER_REASON}"' \n**Build URL:** '"${buildurl}display/redirect"' \n"}],
+              "username": "Github Actions"}' ${{ secrets.DISCORD_WEBHOOK }}
+          fi

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,8 @@
 
 # jenkins variables
 project_name: docker-baseimage-alpine-nginx
-external_type: os
+external_type: na
+custom_version_command: "echo $(curl -sL http://dl-cdn.alpinelinux.org/alpine/v3.19/main/x86_64/APKINDEX.tar.gz | tar -xz -C /tmp && awk '/^P:'\"nginx\"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://')_$(curl -sL http://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz | tar -xz -C /tmp && awk '/^P:'\"php83\"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://')"
 release_type: stable
 release_tag: "3.19"
 ls_branch: master


### PR DESCRIPTION
This adds external versioning to the 3.19 nginx baseimage so that whenever php or nginx get updated in alpine, there will be a new baseimage build within the hour. Current unversioned base causes version mismatches when baseimage contains older versions of either nginx or php modules, but the downstream installs newer versions