### PR TITLE
Fixes #193: use strict IPv4 regex in nginx resolver to prevent crash

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -47,7 +47,7 @@ touch /config/nginx/resolver.conf
 if ! grep -q 'resolver' /config/nginx/resolver.conf; then
     RESOLVERRAW=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
     for i in ${RESOLVERRAW}; do
-        if [[ "$(awk -F ':' '{print NF-1}' <<<"${i}")" -le 2 ]]; then
+        if [[ "${i}" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
             RESOLVER="${RESOLVER} ${i}"
         fi
     done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-alpine-nginx/blob/3.23/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Fixes #193. This PR addresses a critical Nginx startup failure in the /etc/s6-overlay/s6-rc.d/init-nginx/run script.

The previous logic used `awk -F ':' '{print NF-1}'` to filter IPv6 addresses from `/etc/resolv.conf`. However, this method fails to account for compressed IPv6 addresses (e.g., fd00::1), which only contain two colons and thus bypass the filter. This results in an unformatted IPv6 address being written to `/config/nginx/resolver.conf` without brackets [], causing the Nginx error: `[emerg] invalid port in resolver "fd00::1"`.

The fix implements a declarative regex to strictly validate IPv4 addresses, ensuring only valid IPv4 entries are passed to the resolver configuration.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
In dual-stack environments (common in RHEL/Podman setups), both IPv4 and IPv6 nameservers are automatically passed into the container's `/etc/resolv.conf`.

This PR prevents the container from entering a crash loop by ensuring that compressed IPv6 addresses are correctly ignored rather than being misinterpreted as IPv4. By switching to a declarative regex validation `^[0-9]{1,3}(\.[0-9]{1,3}){3}$`, we eliminate the edge cases inherent in the previous colon-counting approach, providing a more robust and predictable initialization process.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Environment: RHEL 10.1 with dual-stack networking and Podman.

- Test Case: Added nameserver `10.0.0.1` and `fd00::1` to the host's `/etc/resolv.conf`.

```quadlet
# librespeed.container
[Container]
ContainerName=librespeed
Environment=PUID=3013 PGID=3013
DNS=10.0.0.1
Image=lscr.io/linuxserver/librespeed:latest
PublishPort=3013:80

[Service]
Restart=always
```
## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

- Closes #193